### PR TITLE
Herm thresh

### DIFF
--- a/dev/core/EigenSolver.m
+++ b/dev/core/EigenSolver.m
@@ -6,33 +6,60 @@
 % Oliver Thomson Brown
 % 2016-10-03
 %
-% [eigVector, eigValue] = EigenSolver(effL, HERMITIAN, THRESHOLD)
-% [eigVector, eigValue] = EigenSolver(effL, HERMITIAN, THRESHOLD, initVec)
+% [eigVector, eigValue] = EigenSolver(effL, HERMITIAN = true,
+%                                       HERMITICITY_THRESHOLD)
+% [eigVector, eigValue] = EigenSolver(effL, HERMITIAN = false, initVec)
 %
 % RETURN
-% eigVector:    (complex) double, the desired eigenvector of the effective %                Liouvillian
+% eigVector:    (complex) double, the desired eigenvector of the effective
+%                Liouvillian
 % eigValue:     (complex) double, the eigenvalue corresponding to eigVector
 %
 % INPUT
-% effL:         (complex) double, effective Liouvillian for some site in
-%               the system
-% HERMITIAN:    bool, true if effL is hermitian, in which case PRIMME will
-%               be used instead of eigs, as ARPACK struggles with smallest
-%               magnitude eigenvalues
-% initVec:      (complex) double, OPTIONAL, initial guess for the
-%               eigenvector -- only used in the non-hermitian case PRIMME's
-%               Matlab interface does not currently support this
+% effL:                     (complex) double, effective Liouvillian for
+%                           some site in the system
+% HERMITIAN:                bool, true if effL is hermitian, in which case
+%                           PRIMME will be used instead of eigs, as ARPACK
+%                           struggles with smallest magnitude eigenvalues
+% HERMITICITY_THRESHOLD:    (complex) double, OPTIONAL, should ONLY be
+%                           supplied if HERMITIAN = true, threshold at
+%                           which function will reject mpo as probably not
+%                           actually Hermitian -- in Stationary this is
+%                           set at 0.1 * the smallest value in the mpo
+% initVec:                  (complex) double, OPTIONAL, initial guess for
+%                           the eigenvector -- only used in the
+%                           non-hermitian case PRIMME's Matlab interface
+%                           does not currently support this
 
-function [eigVector, eigValue] = EigenSolver(effL, HERMITIAN, THRESHOLD, varargin)
+function [eigVector, eigValue] = EigenSolver(effL, HERMITIAN, varargin)
+    narginchk(2, 3);
+
     if HERMITIAN
-        % clean effL as primme has no tolerance for non-hermitian input
-        epsilon = full(max(max(abs(effL - ctranspose(effL)))));
-        fprintf('Hermiticity error: %g\n', epsilon);
-        if epsilon > (THRESHOLD / 2);
-            ME = MException('EigenSolver:badHermiticity', ['The error',...
-            'in L'' - L was large. Supplied MPO may not be Hermitian.']);
-            throw(ME);
+        % solve hermitian product of L
+        if nargin == 3
+            % if HERMITICITY_THRESHOLD is supplied check difference
+            % between L and L'
+            if numel(varargin{1}) == 1
+                % here we check it's a number not a vector
+                epsilon = full(max(max(abs(effL - ctranspose(effL)))));
+                fprintf('Hermiticity error: %g\n', epsilon);
+
+                if epsilon > varargin{1}
+                    ME = MException('EigenSolver:badHermiticity',  ...
+                    ['The error in L'' - L was large. Supplied MPO', ...
+                     ' may not be Hermitian.']);
+                    throw(ME);
+                end
+            else
+                ME = MException('EigenSolver:badHermiticityThreshold', ...
+                ['The supplied Hermiticity Threshold appears to be a', ...
+                 ' vector. Was it intended as an initVec? Type ''help', ...
+                 ' EigenSolver'' for an explanation of input arguments.']);
+                throw(ME);
+            end
         end
+
+        % clean effL as primme has no tolerance for non-hermitian input
         effL = (effL + ctranspose(effL))/2;
 
         opts = struct('eps', 1E-14);
@@ -41,11 +68,23 @@ function [eigVector, eigValue] = EigenSolver(effL, HERMITIAN, THRESHOLD, varargi
         [eigVector, eigValue] = primme_eigs(effL, 1, 'SM', opts);
         fprintf('\n');
     else
-        if nargin > 3
-            opts.v0 = varargin{1};
+        % solve L directly
+        opts = struct('maxit', 500);
+
+        if nargin == 3
+            % and here we check it's a vector not a number
+            if numel(varargin{1}) > 1
+                opts.v0 = varargin{1};
+            else
+                ME = MException('EigenSolver:badInitVec', ...
+                ['The supplied initVec appears to be a scalar. Was', ...
+                 ' it intended to be a Hermiticity threshold? Type', ...
+                 ' ''help EigenSolver'' for an explanation of input', ...
+                 ' arguments.']);
+                throw(ME);
+            end
         end
 
-        opts.maxit = 500;
         [eigVector, eigValue] = eigs(effL, 1, 'lr', opts);
     end
 end

--- a/dev/top/Stationary.m
+++ b/dev/top/Stationary.m
@@ -57,6 +57,12 @@ function [dmpoStat, eigTrack] = Stationary(dmpoInit, mpo, THRESHOLD, variant)
             'Liouvillian size: %g\n'], THRESHOLD, MAX_DIM, MAX_LDIM);
     if HERMITIAN
         fprintf('\tEffective Liouvillian: Hermitian Product\n\n');
+        HERMITICITY_THRESHOLD = Inf;
+        for site = 1 : 1 : LENGTH
+            tmpMin = abs(min(min(min(min(min(min(mpo{site})))))));
+            HERMITICITY_THRESHOLD = min(HERMITICITY_THRESHOLD, tmpMin);
+        end
+        HERMITICITY_THRESHOLD = HERMITICITY_THRESHOLD / 10;
     else
         fprintf('\tEffective Liouvillian: Non-Hermitian\n\n');
         ARPACK_msgID = 'MATLAB:eigs:ARPACKroutineErrorMinus14';
@@ -95,15 +101,15 @@ function [dmpoStat, eigTrack] = Stationary(dmpoInit, mpo, THRESHOLD, variant)
             effL = EffL(site, dmpoStat, mpo, left, right);
 
             if HERMITIAN
-                [update, eig] = EigenSolver(effL, HERMITIAN, THRESHOLD);
+                [update, eig] = EigenSolver(effL, HERMITIAN, ...
+                                            HERMITICITY_THRESHOLD);
             else
                 % we can supply an initial guess to eigs, so we use the
                 % current site tensor, to aid convergence
                 siteVec = permute(dmpoStat{site}, [2, 1, 3, 4]);
                 siteVec = reshape(siteVec, [ROW_SIZE*COL_SIZE*HILBY^2, 1]);
                 try
-                    [update, eig] = EigenSolver(effL, HERMITIAN, ...
-                                                THRESHOLD, siteVec);
+                    [update, eig] = EigenSolver(effL, HERMITIAN, siteVec);
                 catch ME
                     if strcmp(ME.identifier, ARPACK_msgID)
                         fname = sprintf('mpostat%uX%u_failed.mat', ...

--- a/dev/top/Stationary.m
+++ b/dev/top/Stationary.m
@@ -59,7 +59,9 @@ function [dmpoStat, eigTrack] = Stationary(dmpoInit, mpo, THRESHOLD, variant)
         fprintf('\tEffective Liouvillian: Hermitian Product\n\n');
         HERMITICITY_THRESHOLD = Inf;
         for site = 1 : 1 : LENGTH
-            tmpMin = abs(min(min(min(min(min(min(mpo{site})))))));
+            siteMPO = abs(mpo{site});
+            siteMPO = siteMPO(siteMPO > 0);
+            tmpMin = min(min(min(min(min(min(siteMPO))))));
             HERMITICITY_THRESHOLD = min(HERMITICITY_THRESHOLD, tmpMin);
         end
         HERMITICITY_THRESHOLD = HERMITICITY_THRESHOLD / 10;

--- a/testing/coreTests/EigenSolverTest.m
+++ b/testing/coreTests/EigenSolverTest.m
@@ -15,10 +15,20 @@ classdef (SharedTestFixtures={matlab.unittest.fixtures.PathFixture('../../dev', 
             'EigenSolver:badHermiticity');
         end
 
+        function testThrowBadHermiticityThreshold(tc)
+            tc.fatalAssertError(@()EigenSolver(tc.effL, true,  ...
+            rand(3, 1)), 'EigenSolver:badHermiticityThreshold');
+        end
+
+        function testThrowBadInitVec(tc)
+            tc.fatalAssertError(@()EigenSolver(tc.effL, false, 1), ...
+            'EigenSolver:badInitVec');
+        end
+
         function testHermitian(tc)
             HERMITIAN = true;
             H = ctranspose(tc.effL) * tc.effL;
-            [vec, val] = EigenSolver(H, HERMITIAN, 1E-9);
+            [vec, val] = EigenSolver(H, HERMITIAN);
 
             actualVal = 0;
             actualVec = [ 0.302322027807821 + 0.345148819050045i;
@@ -32,7 +42,7 @@ classdef (SharedTestFixtures={matlab.unittest.fixtures.PathFixture('../../dev', 
 
         function testNonHermitian(tc)
             HERMITIAN = false;
-            [vec, val] = EigenSolver(tc.effL, HERMITIAN, 1E-9);
+            [vec, val] = EigenSolver(tc.effL, HERMITIAN);
 
             actualVal = 1.920620363439616 + 0.618180731783746i;
             actualVec = [0.909915536697958;


### PR DESCRIPTION
Passes validation. Should prevent unreasonable throwing of the badHermiticity error, but should still guard against trying to run a Hermitian calculation with a non-Hermitian operator, and vice versa.